### PR TITLE
Fix: Error Propagation

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,20 +1,27 @@
-use std::io::Error;
+use std::error::Error;
 use std::process::{Child, Command};
 use which::which;
 
-pub fn verify_binary(binary: &str, error_context: &str) {
-    which(binary)
-        .expect(format!("{} Binary file '{}' does not exists", error_context, binary).as_str());
+pub fn verify_binary(binary: &str) -> Result<(), Box<dyn Error>> {
+    match which(binary) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(format!("Binary file '{}' does not exists: ({})", binary, err).into())
+    }
 }
 
 pub struct DefaultExecutor {}
 
 impl DefaultExecutor {
-    pub fn run(&self, command: Vec<String>) -> Result<Child, Error> {
-        verify_binary(&command[0].as_str(), "(executor::run)");
+    pub fn run(&self, command: Vec<String>) -> Result<Child, Box<dyn Error>> {
+        if let Err(err) = verify_binary(&command[0].as_str()) {
+            return Err(format!("(executor::run) {}", err).into());
+        }
 
-        let child = Command::new(command[0].clone()).args(&command[1..]).spawn();
+        let child = Command::new(command[0].clone())
+            .args(&command[1..])
+            .spawn()
+            .expect("(executor::run) run command");
 
-        return child;
+        return Ok(child);
     }
 }

--- a/src/playbook.rs
+++ b/src/playbook.rs
@@ -267,7 +267,9 @@ impl Default for AnsiblePlaybookCmd<'_> {
 impl AnsiblePlaybookCmd<'_> {
     /// run playbooks
     pub fn run(&self) -> Result<Child, Box<dyn Error + '_>> {
-        verify_binary(self.binary, "(playbook::run)");
+        if let Err(err) = verify_binary(self.binary) {
+            return Err(format!("(playbook::run) {}", err).into());
+        }
 
         match self.command() {
             Ok(command) => {

--- a/tests/executor.rs
+++ b/tests/executor.rs
@@ -5,16 +5,18 @@ mod tests {
     use std::fs;
 
     #[test]
-    #[should_panic]
     #[allow(unused_must_use)]
-    fn should_fail_() {
+    fn should_fail_if_command_doesnt_exists() {
         let executor = DefaultExecutor {};
         let command = vec!["non-existing-binary", "-i", "127.0.0.1,"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        executor.run(command);
+        match executor.run(command) {
+            Err(_) => {}
+            _ => panic!("Should return Err"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
`executor::verify_binary` now returns an error instead of panic