### PR TITLE
Improve Exports (BREAKING)

### DIFF
--- a/examples/ansible-playbook-simple/main.rs
+++ b/examples/ansible-playbook-simple/main.rs
@@ -1,5 +1,4 @@
-use rs_ansible::options::*;
-use rs_ansible::playbook::*;
+use rs_ansible::*;
 
 fn main() {
     let conn_opts = AnsibleConnectionOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
-pub mod executor;
-pub mod options;
-pub mod playbook;
+mod executor;
+mod options;
+mod playbook;
+
+pub use executor::*;
+pub use options::*;
+pub use playbook::*;

--- a/tests/executor.rs
+++ b/tests/executor.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::test_utils::*;
-    use rs_ansible::executor::*;
+    use rs_ansible::*;
     use std::fs;
 
     #[test]

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use rs_ansible::options::*;
+    use rs_ansible::*;
 
     #[test]
     fn generate_connection_options() {

--- a/tests/playbook.rs
+++ b/tests/playbook.rs
@@ -1,9 +1,7 @@
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-
-    use rs_ansible::options::*;
-    use rs_ansible::playbook::*;
+    use rs_ansible::*;
 
     #[test]
     fn generate_connection_options() {

--- a/tests/playbook.rs
+++ b/tests/playbook.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
     use rs_ansible::*;
+    use serde_json::json;
 
     #[test]
     fn generate_connection_options() {


### PR DESCRIPTION
Refactor API for dev-friendliness.

Before:
```rs
use rs_ansible::options::{...};
use rs_ansible::playbook::{...};
```
Now:
```rs
use rs_ansible::{...};
```